### PR TITLE
Gestions des paramètres de objet_poste

### DIFF
--- a/sql/20180116_0001_relais_poste.sql
+++ b/sql/20180116_0001_relais_poste.sql
@@ -40,6 +40,6 @@ COMMENT ON COLUMN public.objets_poste.opost_dest_perso_cod IS 'cod du personnage
 INSERT INTO public.lieu_type (tlieu_libelle, tlieu_url)  VALUES ( 'Relais de la poste', 'relais_poste.php');
 
 INSERT INTO type_evt (  tevt_libelle , tevt_texte )  VALUES
-('Transaction', '[perso_cod1] a déposé un objet au relais de la poste.'),
-('Transaction', '[perso_cod1] a retiré un objet au relais de la poste.'),
-('Transaction', 'Un objet de [perso_cod1] a été consfisqué par le relais de la poste.');
+('Relais poste', '[perso_cod1] a déposé un objet au relais de la poste.'),
+('Relais poste', '[perso_cod1] a retiré un objet au relais de la poste.'),
+('Relais poste', 'Un objet de [perso_cod1] a été consfisqué par le relais de la poste.');

--- a/sql/20180118_0001_relais_poste.sql
+++ b/sql/20180118_0001_relais_poste.sql
@@ -1,0 +1,4 @@
+INSERT INTO public.parametres(parm_type, parm_desc, parm_valeur, parm_valeur_texte) VALUES 
+( 'Integer', 'Relais de la poste: Montant des frais de port d''un colis en Bzf/Kilo', 100, null),
+( 'Text', 'Relais de la poste: delai de livraison d''un colis (chaine ajoutée à la date par strtotime)', null, '5 DAYS'),
+( 'Integer', 'Relais de la poste: delai de confiscation d''un colis (en nombre de mois)', 2, null);


### PR DESCRIPTION
Cette "_pull request_" permet la gestion des paramètres de "objet_poste" par l'interface d'admin.

**IMPORTANT:** La mise à jour demande l'insertion de nouveaux paramètres d'admin dans "_public.parametres_". Ses mises à jour peuvent être faites par le script: **sql/20180118_0001_relais_poste.sql**

Aussi, dans le **wiki** je propose de remplacer ça:
```
su - delain
for import in `find /home/delain/delain/sql -type f| grep -v "initial_import.sql"|sort`; do
psql -U webdelain -f $import -d delain
done
exit
```
Par ça:
```
su - delain
export PGPASSWORD='mettre-ici-le-password-de-webdelain' 
for import in `find /home/delain/delain/sql -type f| grep -v "initial_import.sql"|sort`; 
do psql -U webdelain -f $import -d delain; 
done
exit
```
Cela permet d'éviter la saisie du password "webdelain" sur l'import de chaque script.