### PR TITLE
 BUG: remise dans l'ordre des events des persos

### DIFF
--- a/web/www/jeu_test/admin_gestion_droits.php
+++ b/web/www/jeu_test/admin_gestion_droits.php
@@ -161,6 +161,7 @@ if ($erreur == 0)
             echo "<table class=\"soustitre2\ cellspacing=\"2\" cellpadding=\"2\">";
             echo "<tr>";
             echo "<td class=\"soustitre2\"><p><b>Nom du compte</b></p></td>";
+            echo "<td class=\"soustitre2\" style=\"min-width: 60px;\"><p><b>Der. Connex.</b></p></td>";
             echo "<td class=\"soustitre2\"><p><b>Perso</b></p></td>";
             echo "<td class=\"soustitre2\"><p><b>Monstres</b></p></td>";
             echo "<td class=\"soustitre2\"><p><b>Monstre<br>Gen.</b></p></td>";
@@ -182,11 +183,12 @@ if ($erreur == 0)
             echo "<td class=\"soustitre2\"><p><b>Magie</b></p></td>";
             echo "</tr>";
 
-            $req_pers = "select compt_cod, compt_nom, compt_mail, compt_droit.* from compte join compt_droit on dcompt_compt_cod=compt_cod where compt_actif='$filtre_actif' order by compt_nom";
+            $req_pers = "select compt_cod, compt_nom, compt_mail, TO_CHAR(compt_der_connex, 'YY-MM-DD HH:MI') compt_der_connex, compt_droit.* from compte join compt_droit on dcompt_compt_cod=compt_cod where compt_actif='$filtre_actif' order by compt_nom";
             $db->query($req_pers);
             while($db->next_record()){
                 echo "<tr>";
                 echo "<td class=\"soustitre2\"><span title=\"".$db->f("compt_mail")."\"><a href=\"admin_gestion_droits.php?methode=et3&vcompte=".$db->f("compt_cod")."\">".$db->f("compt_nom")."</a></span></td>";
+                echo "<td style=\"text-align: center;\" class=\"soustitre2\">".$db->f("compt_der_connex")."</td>";
                 echo "<td style=\"text-align: center;\" class=\"soustitre2\">".$db->f("dcompt_modif_perso")."</td>";
                 echo "<td style=\"text-align: center;\" class=\"soustitre2\">".$db->f("dcompt_creer_monstre")."</td>";
                 echo "<td style=\"text-align: center;\" class=\"soustitre2\">".$db->f("dcompt_modif_gmon")."</td>";

--- a/web/www/jeu_test/evenements.php
+++ b/web/www/jeu_test/evenements.php
@@ -57,7 +57,7 @@ att.perso_nom as attaquant, def.perso_nom as cible, soi.perso_nom as soimeme
 	left outer join perso def ON levt_cible = def.perso_cod
 	where levt_perso_cod1 = $perso_cod
 	$restr
-	order by levt_cod desc
+	order by levt_date desc,levt_cod desc
 	limit 20
 	offset $evt_start ";
 $db->query($req_evt);

--- a/web/www/jeu_test/visu_evt_perso.php
+++ b/web/www/jeu_test/visu_evt_perso.php
@@ -93,7 +93,7 @@ if ($db->is_admin($compt_cod))
 		left outer join perso p1 ON p1.perso_cod = levt_attaquant
 		left outer join perso p2 ON p2.perso_cod = levt_cible
 		where levt_perso_cod1 = ' . $visu . '
-		order by levt_cod desc
+		order by levt_date desc,levt_cod desc
 		limit 20
 		offset ' . $pevt_start;
 
@@ -136,7 +136,7 @@ else
 		left outer join perso p2 ON p2.perso_cod = levt_cible
 		where levt_perso_cod1 = ' . $visu . '
 			and levt_visible = \'O\'
-		order by levt_cod desc
+		order by levt_date desc,levt_cod desc
 		limit 20
 		offset ' . $pevt_start;
 


### PR DESCRIPTION
Pour l'affichage dans les pages des joueurs, les events étaient triés par oid, or quand de nombreuses lignes d'évents sont insérer rapidement, les oid ne correspondent pas forcément à l'ordre réel des événements.
A l'affichage, j'ai modifié l'ordre de tri pour  favoriser la date de l’événement plutôt que l'oid.

Aussi:
Ajout de la date de dernière conn. d'un compte dans la section admin liste des droits.