### PR TITLE
BUG: remise dans l'ordre des events des persos

### DIFF
--- a/web/www/jeu_test/evenements.php
+++ b/web/www/jeu_test/evenements.php
@@ -57,7 +57,7 @@ att.perso_nom as attaquant, def.perso_nom as cible, soi.perso_nom as soimeme
 	left outer join perso def ON levt_cible = def.perso_cod
 	where levt_perso_cod1 = $perso_cod
 	$restr
-	order by levt_date desc,levt_cod desc
+	order by levt_cod desc
 	limit 20
 	offset $evt_start ";
 $db->query($req_evt);

--- a/web/www/jeu_test/visu_evt_perso.php
+++ b/web/www/jeu_test/visu_evt_perso.php
@@ -93,7 +93,7 @@ if ($db->is_admin($compt_cod))
 		left outer join perso p1 ON p1.perso_cod = levt_attaquant
 		left outer join perso p2 ON p2.perso_cod = levt_cible
 		where levt_perso_cod1 = ' . $visu . '
-		order by levt_date desc,levt_cod desc
+		order by levt_cod desc
 		limit 20
 		offset ' . $pevt_start;
 
@@ -136,7 +136,7 @@ else
 		left outer join perso p2 ON p2.perso_cod = levt_cible
 		where levt_perso_cod1 = ' . $visu . '
 			and levt_visible = \'O\'
-		order by levt_date desc,levt_cod desc
+		order by levt_cod desc
 		limit 20
 		offset ' . $pevt_start;
 


### PR DESCRIPTION
Retour au tri sur oid, le problème est insoluble:
- si on trie sur oid, les dates ne sont pas dans l'ordre.
- si on trie sur date, ce sont les événements qui ne sont pas réellement dans l'ordre. 

On va privilégier l'ordre des actions plutôt que la date.