### PR TITLE
Correction de la description du coût en PA d'un passage.

### DIFF
--- a/web/www/jeu_test/modif_etage3bis.php
+++ b/web/www/jeu_test/modif_etage3bis.php
@@ -360,7 +360,7 @@ if ($erreur == 0)
                         } ?>>oui
                         </option>
                     </select>
-                    Coût en pa (pour les passages ondulants uniquement)<input type="text" name="cout_pa"
+                    Coût en PA (pour les passages ondulants, passages tunnels, etc.) <input type="text" name="cout_pa"
                                                                               value="<?php echo $cout_pa ?>">
                     <input type="submit" value="Modifier !" class='test'>
                 </form>


### PR DESCRIPTION
La description originale donne un coût en PA uniquement pour les passages ondulants, tandis que d'autres sont affectés (induit en erreur).